### PR TITLE
docs: 프론트엔드 극한 챌린지 설계 및 구현 계획 추가

### DIFF
--- a/docs/superpowers/plans/2026-04-07-extreme-frontend-implementation.md
+++ b/docs/superpowers/plans/2026-04-07-extreme-frontend-implementation.md
@@ -81,7 +81,7 @@ frontend/
 
 ## 벤치마크 기준값
 
-각 Phase에서 측정하여 `benchmarks/phase-XX.md` 에 기록:
+각 Phase에서 측정하여 `frontend/benchmarks/fe-phase-XX-*.md` 에 기록:
 
 | 지표 | 측정 도구 | 목표 (Phase 13 기준) |
 |------|-----------|---------------------|

--- a/docs/superpowers/plans/2026-04-07-extreme-frontend-implementation.md
+++ b/docs/superpowers/plans/2026-04-07-extreme-frontend-implementation.md
@@ -1,0 +1,109 @@
+# 극한 프론트엔드 성능 챌린지 — 마스터 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Next.js 기반 극한 트래픽 게시판 프론트엔드를 13개 Phase에 걸쳐 naive → 최적화 순서로 구현하며, 각 Phase에서 성능 병목을 체험하고 수치로 증명한다.
+
+**Architecture:** 백엔드 12 Phase에 동기화 + 프론트엔드 전용 3개 Phase 삽입. 각 Phase는 "naive 구현 → 병목 체험 → 최적화 → 벤치마크 증명" 루프를 따른다.
+
+**Tech Stack:** Next.js 16 (App Router), TypeScript (strict), Tailwind CSS, TanStack Query, Zustand, msw, Playwright, Lighthouse CI
+
+**Design Spec:** `docs/superpowers/specs/2026-04-07-extreme-frontend-design.md`
+
+---
+
+## 학습 루프
+
+```
+naive 구현 → 병목 체험 → "왜 느린가?" 원리 이해 → 최적화 → 벤치마크로 증명
+```
+
+각 Phase를 완료하면 `docs/progress/` 에 결과를 기록한다.
+
+---
+
+## 프로젝트 디렉토리 구조
+
+```
+frontend/
+├── src/
+│   ├── app/                        # Next.js App Router
+│   │   ├── layout.tsx              # 루트 레이아웃
+│   │   ├── page.tsx                # 메인 (게시글 목록)
+│   │   ├── posts/
+│   │   │   ├── [id]/page.tsx       # 게시글 상세
+│   │   │   └── new/page.tsx        # 게시글 작성
+│   │   └── dashboard/page.tsx      # 성능 대시보드 (FE-10~)
+│   ├── components/
+│   │   ├── posts/                  # 게시글 관련 컴포넌트
+│   │   ├── common/                 # 공통 UI
+│   │   └── dashboard/              # 성능 대시보드
+│   ├── hooks/                      # 커스텀 훅
+│   ├── lib/
+│   │   ├── api/                    # API 클라이언트
+│   │   ├── cache/                  # 캐시 전략 (FE-4~)
+│   │   └── performance/            # 성능 측정 유틸 (FE-10~)
+│   ├── store/                      # Zustand 스토어 (FE-7~)
+│   ├── mocks/                      # msw 핸들러
+│   └── workers/                    # Service Worker (FE-9~)
+├── public/
+├── tests/
+│   ├── e2e/                        # Playwright E2E
+│   └── performance/                # 벤치마크 스크립트
+├── benchmarks/                     # Phase별 벤치마크 결과
+├── next.config.ts
+├── tailwind.config.ts
+├── tsconfig.json
+└── package.json
+```
+
+---
+
+## Phase 로드맵
+
+| Phase | 설명 | 상세 계획 | 상태 |
+|-------|------|-----------|------|
+| **FE-1** | 프로젝트 셋업 + Naive UI | [fe-phase-01-foundation.md](fe-phases/fe-phase-01-foundation.md) | - |
+| **FE-2** | 렌더링 병목 체험 | [fe-phase-02-bottleneck.md](fe-phases/fe-phase-02-bottleneck.md) | - |
+| **FE-3** | 리스트 최적화 | [fe-phase-03-list-optimization.md](fe-phases/fe-phase-03-list-optimization.md) | - |
+| **FE-4** | 데이터 페칭 + 캐싱 | [fe-phase-04-caching.md](fe-phases/fe-phase-04-caching.md) | - |
+| **★ FE-5** | 대량 렌더링 극한 | [fe-phase-05-virtualization.md](fe-phases/fe-phase-05-virtualization.md) | - |
+| **FE-6** | 동시성 UI 패턴 | [fe-phase-06-concurrency.md](fe-phases/fe-phase-06-concurrency.md) | - |
+| **FE-7** | 상태 관리 + Smart Polling | [fe-phase-07-state-polling.md](fe-phases/fe-phase-07-state-polling.md) | - |
+| **FE-8** | 이미지 업로드 UX | [fe-phase-08-image-upload.md](fe-phases/fe-phase-08-image-upload.md) | - |
+| **★ FE-9** | 네트워크 극한 | [fe-phase-09-network.md](fe-phases/fe-phase-09-network.md) | - |
+| **FE-10** | 프론트엔드 모니터링 | [fe-phase-10-monitoring.md](fe-phases/fe-phase-10-monitoring.md) | - |
+| **FE-11** | 스트레스 테스트 | [fe-phase-11-stress.md](fe-phases/fe-phase-11-stress.md) | - |
+| **★ FE-12** | 메모리/성능 극한 | [fe-phase-12-memory.md](fe-phases/fe-phase-12-memory.md) | - |
+| **FE-13** | 프로덕션 배포 + CDN | [fe-phase-13-deploy.md](fe-phases/fe-phase-13-deploy.md) | - |
+
+---
+
+## 벤치마크 기준값
+
+각 Phase에서 측정하여 `benchmarks/phase-XX.md` 에 기록:
+
+| 지표 | 측정 도구 | 목표 (Phase 13 기준) |
+|------|-----------|---------------------|
+| LCP | web-vitals | < 2.5s |
+| INP | web-vitals | < 200ms |
+| CLS | web-vitals | < 0.1 |
+| 번들 크기 (gzipped) | @next/bundle-analyzer | < 150KB (JS) |
+| 10만건 렌더링 시간 | Performance API | 가상화 후 60fps 유지 |
+| 메모리 증가 (10분) | Chrome DevTools Memory | < 10MB |
+| Lighthouse 성능 점수 | Lighthouse CI | > 90 |
+
+---
+
+## 백엔드 협업 포인트
+
+백엔드 Phase가 완료될 때까지 msw로 mock API 사용. 전환 시점:
+
+| 백엔드 Phase | 프론트엔드 전환 |
+|-------------|----------------|
+| BE-1 완료 | msw → 실제 CRUD API |
+| BE-3 완료 | 커서 페이지네이션 API 연동 |
+| BE-4 완료 | Cache-Control 헤더 활용 |
+| BE-6 완료 | 멱등성 키 실제 API 연동 |
+| BE-8 완료 | Presigned URL 실제 발급 |
+| BE-12 완료 | 프로덕션 배포 |

--- a/docs/superpowers/plans/2026-04-07-extreme-frontend-implementation.md
+++ b/docs/superpowers/plans/2026-04-07-extreme-frontend-implementation.md
@@ -64,18 +64,18 @@ frontend/
 | Phase | 설명 | 상세 계획 | 상태 |
 |-------|------|-----------|------|
 | **FE-1** | 프로젝트 셋업 + Naive UI | [fe-phase-01-foundation.md](fe-phases/fe-phase-01-foundation.md) | - |
-| **FE-2** | 렌더링 병목 체험 | [fe-phase-02-bottleneck.md](fe-phases/fe-phase-02-bottleneck.md) | - |
-| **FE-3** | 리스트 최적화 | [fe-phase-03-list-optimization.md](fe-phases/fe-phase-03-list-optimization.md) | - |
-| **FE-4** | 데이터 페칭 + 캐싱 | [fe-phase-04-caching.md](fe-phases/fe-phase-04-caching.md) | - |
-| **★ FE-5** | 대량 렌더링 극한 | [fe-phase-05-virtualization.md](fe-phases/fe-phase-05-virtualization.md) | - |
-| **FE-6** | 동시성 UI 패턴 | [fe-phase-06-concurrency.md](fe-phases/fe-phase-06-concurrency.md) | - |
-| **FE-7** | 상태 관리 + Smart Polling | [fe-phase-07-state-polling.md](fe-phases/fe-phase-07-state-polling.md) | - |
-| **FE-8** | 이미지 업로드 UX | [fe-phase-08-image-upload.md](fe-phases/fe-phase-08-image-upload.md) | - |
-| **★ FE-9** | 네트워크 극한 | [fe-phase-09-network.md](fe-phases/fe-phase-09-network.md) | - |
-| **FE-10** | 프론트엔드 모니터링 | [fe-phase-10-monitoring.md](fe-phases/fe-phase-10-monitoring.md) | - |
-| **FE-11** | 스트레스 테스트 | [fe-phase-11-stress.md](fe-phases/fe-phase-11-stress.md) | - |
-| **★ FE-12** | 메모리/성능 극한 | [fe-phase-12-memory.md](fe-phases/fe-phase-12-memory.md) | - |
-| **FE-13** | 프로덕션 배포 + CDN | [fe-phase-13-deploy.md](fe-phases/fe-phase-13-deploy.md) | - |
+| **FE-2** | 렌더링 병목 체험 | `fe-phase-02-bottleneck.md` (상세 계획 PR 예정) | - |
+| **FE-3** | 리스트 최적화 | `fe-phase-03-list-optimization.md` (상세 계획 PR 예정) | - |
+| **FE-4** | 데이터 페칭 + 캐싱 | `fe-phase-04-caching.md` (상세 계획 PR 예정) | - |
+| **★ FE-5** | 대량 렌더링 극한 | `fe-phase-05-virtualization.md` (상세 계획 PR 예정) | - |
+| **FE-6** | 동시성 UI 패턴 | `fe-phase-06-concurrency.md` (상세 계획 PR 예정) | - |
+| **FE-7** | 상태 관리 + Smart Polling | `fe-phase-07-state-polling.md` (상세 계획 PR 예정) | - |
+| **FE-8** | 이미지 업로드 UX | `fe-phase-08-image-upload.md` (상세 계획 PR 예정) | - |
+| **★ FE-9** | 네트워크 극한 | `fe-phase-09-network.md` (상세 계획 PR 예정) | - |
+| **FE-10** | 프론트엔드 모니터링 | `fe-phase-10-monitoring.md` (상세 계획 PR 예정) | - |
+| **FE-11** | 스트레스 테스트 | `fe-phase-11-stress.md` (상세 계획 PR 예정) | - |
+| **★ FE-12** | 메모리/성능 극한 | `fe-phase-12-memory.md` (상세 계획 PR 예정) | - |
+| **FE-13** | 프로덕션 배포 + CDN | `fe-phase-13-deploy.md` (상세 계획 PR 예정) | - |
 
 ---
 

--- a/docs/superpowers/plans/fe-phases/fe-phase-01-foundation.md
+++ b/docs/superpowers/plans/fe-phases/fe-phase-01-foundation.md
@@ -1062,7 +1062,7 @@ export default async function EditPostPage({ params }: Props) {
 }
 ```
 
-> **주의**: msw는 브라우저에서만 동작한다. Server Component에서 `fetchPost`를 직접 호출하면 msw가 가로채지 않는다. FE-1에서는 수정 페이지를 Client Component로 래핑하는 방식 대신, `PostForm` 컴포넌트가 Client Component이므로 `mode="edit"`와 함께 초기 데이터를 props로 주입할 수 없다. 해결: `EditPostPage`를 Client Component로 전환하거나, 수정 폼에서 직접 fetch하도록 변경한다.
+> **주의**: msw는 브라우저 Service Worker 기반이라 브라우저에서 발생한 요청만 가로챈다. 따라서 Server Component에서 `fetchPost`를 직접 호출하면 FE-1의 기본 msw 설정으로는 인터셉트되지 않는다. 다만 `PostForm`이 Client Component라는 이유만으로 초기 데이터를 props로 주입할 수 없는 것은 아니다. Server Component에서 가져온 직렬화 가능한 데이터(plain object)는 `mode="edit"`와 함께 `post` props로 전달할 수 있다. 실제 제약은 "어디서 fetch가 실행되느냐"이다. 해결 방법은 (1) 서버에서도 모킹이 필요하면 `msw/node` 등으로 서버측 요청까지 모킹하거나, (2) FE-1에서는 edit 페이지 또는 수정 폼에서 클라이언트에서 직접 fetch하도록 구성하는 것이다.
 >
 > **FE-1에서의 실용적 접근**: `src/app/posts/[id]/edit/page.tsx`를 Client Component로 작성:
 

--- a/docs/superpowers/plans/fe-phases/fe-phase-01-foundation.md
+++ b/docs/superpowers/plans/fe-phases/fe-phase-01-foundation.md
@@ -675,7 +675,7 @@ export function PostList() {
   const [error, setError] = useState<string | null>(null);
 
   const pageSize = 20;
-  const totalPages = Math.ceil(total / pageSize);
+  const totalPages = total === 0 ? 1 : Math.ceil(total / pageSize);
 
   useEffect(() => {
     setLoading(true);
@@ -715,8 +715,10 @@ export function PostList() {
           {page} / {totalPages} 페이지 (총 {total.toLocaleString()}개)
         </span>
         <button
-          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-          disabled={page === totalPages}
+          onClick={() =>
+            setPage((p) => (totalPages === 0 ? 1 : Math.min(totalPages, p + 1)))
+          }
+          disabled={totalPages === 0 || page >= totalPages}
           className="px-4 py-2 border rounded disabled:opacity-50"
         >
           다음

--- a/docs/superpowers/plans/fe-phases/fe-phase-01-foundation.md
+++ b/docs/superpowers/plans/fe-phases/fe-phase-01-foundation.md
@@ -1,0 +1,1209 @@
+# FE-1: 프로젝트 셋업 + Naive UI — 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Next.js App Router 기반 게시판 프론트엔드를 셋업하고, 의도적으로 비최적화된 naive CRUD UI를 구현한다. 이후 Phase에서 개선할 기준값(baseline)을 측정한다.
+
+**Architecture:** 백엔드 Phase 1이 완료될 때까지 msw(Mock Service Worker)로 API를 모킹. App Router Server Components + Client Components 혼합. 의도적으로 React.memo, useMemo 없이 구현하여 re-render 폭풍을 허용한다.
+
+**Tech Stack:** Next.js 16.x, TypeScript 5.x (strict), Tailwind CSS 4.x, msw 2.x
+
+**학습 목표:**
+- Next.js App Router 구조 이해 (Server Component vs Client Component)
+- Hydration이란 무엇인가 (서버 HTML → 클라이언트 React 이벤트 연결)
+- React Rendering Pipeline: Reconciliation → Commit
+- "왜 의도적으로 naive하게 만드는가?" → 병목을 직접 체험하기 위해
+
+---
+
+## 파일 구조
+
+```
+frontend/
+├── src/
+│   ├── app/
+│   │   ├── layout.tsx                    # 루트 레이아웃 (새로 생성)
+│   │   ├── page.tsx                      # 게시글 목록 (새로 생성)
+│   │   ├── posts/
+│   │   │   ├── [id]/
+│   │   │   │   └── page.tsx              # 게시글 상세 (새로 생성)
+│   │   │   └── new/
+│   │   │       └── page.tsx              # 게시글 작성 (새로 생성)
+│   ├── components/
+│   │   └── posts/
+│   │       ├── PostCard.tsx              # 목록 아이템 (새로 생성)
+│   │       ├── PostList.tsx              # 목록 컨테이너 (새로 생성)
+│   │       ├── PostForm.tsx              # 작성/수정 폼 (새로 생성)
+│   │       └── PostDetail.tsx            # 상세 뷰 (새로 생성)
+│   ├── lib/
+│   │   └── api/
+│   │       ├── client.ts                 # fetch wrapper (새로 생성)
+│   │       └── posts.ts                  # 게시글 API 함수 (새로 생성)
+│   ├── mocks/
+│   │   ├── handlers.ts                   # msw 핸들러 (새로 생성)
+│   │   ├── browser.ts                    # msw 브라우저 설정 (새로 생성)
+│   │   └── data.ts                       # mock 데이터 생성 (새로 생성)
+│   └── types/
+│       └── post.ts                       # 타입 정의 (새로 생성)
+├── public/
+│   └── mockServiceWorker.js              # msw SW 파일 (msw init 자동 생성)
+├── next.config.ts                        # 새로 생성
+├── tailwind.config.ts                    # 새로 생성
+├── tsconfig.json                         # 자동 생성
+└── package.json                          # 자동 생성
+```
+
+---
+
+## Task 1: Next.js 프로젝트 초기화
+
+**Files:**
+- Create: `frontend/` (디렉토리 전체)
+- Create: `frontend/next.config.ts`
+- Create: `frontend/src/types/post.ts`
+
+### 1-1. 프로젝트 생성
+
+- [ ] **Step 1: Next.js 프로젝트 생성**
+
+프로젝트 루트(`extreme-challenge-with-claude/`)에서 실행:
+
+```bash
+cd /path/to/extreme-challenge-with-claude
+npx create-next-app@latest frontend \
+  --typescript \
+  --tailwind \
+  --eslint \
+  --app \
+  --src-dir \
+  --no-turbopack \
+  --import-alias "@/*"
+```
+
+> 프롬프트가 나오면: TypeScript → Yes, ESLint → Yes, Tailwind → Yes, src/ directory → Yes, App Router → Yes, Turbopack → No (안정성 우선)
+
+- [ ] **Step 2: 의존성 설치 확인**
+
+```bash
+cd frontend
+node --version   # v20+ 필요
+npm --version
+cat package.json | grep '"next"'  # 16.x 확인
+```
+
+- [ ] **Step 3: msw 설치**
+
+```bash
+npm install msw --save-dev
+npx msw init public/ --save
+```
+
+Expected: `public/mockServiceWorker.js` 파일 생성
+
+- [ ] **Step 4: TypeScript strict 설정 확인**
+
+`tsconfig.json`에서 아래 옵션이 있는지 확인:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true
+  }
+}
+```
+
+없으면 `tsconfig.json`에 `"noUncheckedIndexedAccess": true` 추가.
+
+- [ ] **Step 5: next.config.ts 설정**
+
+`frontend/next.config.ts`를 다음으로 교체:
+
+```typescript
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // FE-1: naive 구현 — 최적화 설정 없음
+  // 이미지 최적화는 FE-8에서, 번들 분석은 FE-9에서 추가
+};
+
+export default nextConfig;
+```
+
+- [ ] **Step 6: 개발 서버 기동 확인**
+
+```bash
+npm run dev
+```
+
+Expected: `http://localhost:3000` 에서 Next.js 기본 페이지 렌더링
+
+- [ ] **Step 7: 기본 파일 정리**
+
+`src/app/page.tsx`의 기본 내용을 모두 삭제하고 placeholder로 교체:
+
+```typescript
+export default function Home() {
+  return <main>게시판 준비 중</main>;
+}
+```
+
+`src/app/globals.css`에서 기본 CSS 변수 블록을 유지하되 아래 내용만 남김:
+
+```css
+@import "tailwindcss";
+```
+
+### 1-2. 타입 정의
+
+- [ ] **Step 8: Post 타입 정의 작성**
+
+`src/types/post.ts` 생성:
+
+```typescript
+export interface Post {
+  id: string;
+  title: string;
+  content: string;
+  author: string;
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  createdAt: string; // ISO 8601
+  updatedAt: string;
+}
+
+export interface PostListItem {
+  id: string;
+  title: string;
+  author: string;
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  createdAt: string;
+}
+
+export interface PostListResponse {
+  items: PostListItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasNext: boolean;
+}
+
+export interface CreatePostInput {
+  title: string;
+  content: string;
+  author: string;
+}
+
+export interface UpdatePostInput {
+  title?: string;
+  content?: string;
+}
+
+export interface Comment {
+  id: string;
+  postId: string;
+  content: string;
+  author: string;
+  createdAt: string;
+}
+```
+
+- [ ] **Step 9: 커밋**
+
+```bash
+git add frontend/
+git commit -m "feat(fe): FE-1 Next.js 프로젝트 초기화 (App Router, TypeScript strict, Tailwind, msw)"
+```
+
+---
+
+## Task 2: msw Mock API 설정
+
+**Files:**
+- Create: `frontend/src/mocks/data.ts`
+- Create: `frontend/src/mocks/handlers.ts`
+- Create: `frontend/src/mocks/browser.ts`
+- Modify: `frontend/src/app/layout.tsx`
+
+**학습**: msw는 Service Worker를 이용해 브라우저의 fetch 요청을 가로챈다. 백엔드 없이 프론트엔드를 독립적으로 개발할 수 있는 이유.
+
+- [ ] **Step 1: Mock 데이터 생성 유틸 작성**
+
+`src/mocks/data.ts` 생성:
+
+```typescript
+import type { Post, PostListItem, Comment } from "@/types/post";
+
+let postIdCounter = 1;
+let commentIdCounter = 1;
+
+export function generatePost(overrides?: Partial<Post>): Post {
+  const id = String(postIdCounter++);
+  return {
+    id,
+    title: `테스트 게시글 ${id}`,
+    content: `이것은 게시글 ${id}의 내용입니다. 극한 성능 챌린지를 위한 테스트 데이터입니다.`,
+    author: `user${Math.floor(Math.random() * 100)}`,
+    viewCount: Math.floor(Math.random() * 1000),
+    likeCount: Math.floor(Math.random() * 100),
+    commentCount: Math.floor(Math.random() * 50),
+    createdAt: new Date(Date.now() - Math.random() * 86400000 * 30).toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+export function generatePostListItem(overrides?: Partial<PostListItem>): PostListItem {
+  const post = generatePost();
+  return {
+    id: post.id,
+    title: post.title,
+    author: post.author,
+    viewCount: post.viewCount,
+    likeCount: post.likeCount,
+    commentCount: post.commentCount,
+    createdAt: post.createdAt,
+    ...overrides,
+  };
+}
+
+// 인메모리 DB 역할
+export const db = {
+  posts: Array.from({ length: 20 }, () => generatePost()),
+
+  findPostById(id: string): Post | undefined {
+    return this.posts.find((p) => p.id === id);
+  },
+
+  createPost(input: { title: string; content: string; author: string }): Post {
+    const post = generatePost(input);
+    this.posts.unshift(post);
+    return post;
+  },
+
+  updatePost(id: string, input: { title?: string; content?: string }): Post | undefined {
+    const post = this.posts.find((p) => p.id === id);
+    if (!post) return undefined;
+    Object.assign(post, input, { updatedAt: new Date().toISOString() });
+    return post;
+  },
+
+  deletePost(id: string): boolean {
+    const idx = this.posts.findIndex((p) => p.id === id);
+    if (idx === -1) return false;
+    this.posts.splice(idx, 1);
+    return true;
+  },
+
+  getPaginatedPosts(page: number, pageSize: number) {
+    const start = (page - 1) * pageSize;
+    const items = this.posts.slice(start, start + pageSize).map((p) => ({
+      id: p.id,
+      title: p.title,
+      author: p.author,
+      viewCount: p.viewCount,
+      likeCount: p.likeCount,
+      commentCount: p.commentCount,
+      createdAt: p.createdAt,
+    }));
+    return {
+      items,
+      total: this.posts.length,
+      page,
+      pageSize,
+      hasNext: start + pageSize < this.posts.length,
+    };
+  },
+};
+```
+
+- [ ] **Step 2: msw 핸들러 작성**
+
+`src/mocks/handlers.ts` 생성:
+
+```typescript
+import { http, HttpResponse } from "msw";
+import { db } from "./data";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export const handlers = [
+  // 게시글 목록 (OFFSET 페이지네이션 — naive)
+  http.get(`${API_BASE}/api/v1/posts`, ({ request }) => {
+    const url = new URL(request.url);
+    const page = Number(url.searchParams.get("page") ?? "1");
+    const pageSize = Number(url.searchParams.get("page_size") ?? "20");
+    return HttpResponse.json(db.getPaginatedPosts(page, pageSize));
+  }),
+
+  // 게시글 상세
+  http.get(`${API_BASE}/api/v1/posts/:id`, ({ params }) => {
+    const post = db.findPostById(String(params["id"]));
+    if (!post) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+    post.viewCount += 1; // 조회수 증가 (naive: 매 요청마다)
+    return HttpResponse.json(post);
+  }),
+
+  // 게시글 작성
+  http.post(`${API_BASE}/api/v1/posts`, async ({ request }) => {
+    const body = (await request.json()) as {
+      title: string;
+      content: string;
+      author: string;
+    };
+    const post = db.createPost(body);
+    return HttpResponse.json(post, { status: 201 });
+  }),
+
+  // 게시글 수정
+  http.patch(`${API_BASE}/api/v1/posts/:id`, async ({ params, request }) => {
+    const body = (await request.json()) as { title?: string; content?: string };
+    const post = db.updatePost(String(params["id"]), body);
+    if (!post) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+    return HttpResponse.json(post);
+  }),
+
+  // 게시글 삭제
+  http.delete(`${API_BASE}/api/v1/posts/:id`, ({ params }) => {
+    const ok = db.deletePost(String(params["id"]));
+    if (!ok) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // 좋아요 토글
+  http.post(`${API_BASE}/api/v1/posts/:id/like`, ({ params }) => {
+    const post = db.findPostById(String(params["id"]));
+    if (!post) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+    post.likeCount += 1; // naive: 중복 허용
+    return HttpResponse.json({ likeCount: post.likeCount });
+  }),
+];
+```
+
+- [ ] **Step 3: msw 브라우저 설정 작성**
+
+`src/mocks/browser.ts` 생성:
+
+```typescript
+import { setupWorker } from "msw/browser";
+import { handlers } from "./handlers";
+
+export const worker = setupWorker(...handlers);
+```
+
+- [ ] **Step 4: MSW Provider 컴포넌트 작성**
+
+`src/mocks/MSWProvider.tsx` 생성:
+
+```typescript
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function MSWProvider({ children }: { children: React.ReactNode }) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") {
+      setReady(true);
+      return;
+    }
+    import("./browser").then(({ worker }) => {
+      worker.start({ onUnhandledRequest: "bypass" }).then(() => setReady(true));
+    });
+  }, []);
+
+  if (!ready) return null;
+  return <>{children}</>;
+}
+```
+
+- [ ] **Step 5: 루트 레이아웃에 MSWProvider 연결**
+
+`src/app/layout.tsx`를 다음으로 교체:
+
+```typescript
+import type { Metadata } from "next";
+import "./globals.css";
+import { MSWProvider } from "@/mocks/MSWProvider";
+
+export const metadata: Metadata = {
+  title: "극한 게시판",
+  description: "극한 트래픽 게시판 프론트엔드 챌린지",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="ko">
+      <body>
+        <MSWProvider>{children}</MSWProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+- [ ] **Step 6: 환경변수 파일 생성**
+
+`frontend/.env.local` 생성:
+
+```
+NEXT_PUBLIC_API_URL=http://localhost:8000
+```
+
+`frontend/.env.local`을 `.gitignore`에 추가 (이미 있으면 skip):
+
+```bash
+echo ".env.local" >> .gitignore
+```
+
+- [ ] **Step 7: 개발 서버에서 msw 동작 확인**
+
+```bash
+npm run dev
+```
+
+브라우저 콘솔에서 확인:
+```
+[MSW] Mocking enabled.
+```
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add frontend/src/mocks/ frontend/src/app/layout.tsx frontend/src/types/ frontend/.gitignore
+git commit -m "feat(fe): FE-1 msw mock API 설정 (게시글 CRUD 핸들러)"
+```
+
+---
+
+## Task 3: API 클라이언트 레이어
+
+**Files:**
+- Create: `frontend/src/lib/api/client.ts`
+- Create: `frontend/src/lib/api/posts.ts`
+
+**학습**: fetch wrapper를 직접 만드는 이유 — 에러 처리 일관성, 베이스 URL 중앙화, 향후 인터셉터 추가 용이성.
+
+- [ ] **Step 1: fetch 기본 클라이언트 작성**
+
+`src/lib/api/client.ts` 생성:
+
+```typescript
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export async function apiFetch<T>(
+  path: string,
+  options?: RequestInit,
+): Promise<T> {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new ApiError(response.status, body);
+  }
+
+  // 204 No Content
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}
+```
+
+- [ ] **Step 2: 게시글 API 함수 작성**
+
+`src/lib/api/posts.ts` 생성:
+
+```typescript
+import { apiFetch } from "./client";
+import type {
+  Post,
+  PostListResponse,
+  CreatePostInput,
+  UpdatePostInput,
+} from "@/types/post";
+
+export async function fetchPosts(
+  page = 1,
+  pageSize = 20,
+): Promise<PostListResponse> {
+  return apiFetch(`/api/v1/posts?page=${page}&page_size=${pageSize}`);
+}
+
+export async function fetchPost(id: string): Promise<Post> {
+  return apiFetch(`/api/v1/posts/${id}`);
+}
+
+export async function createPost(input: CreatePostInput): Promise<Post> {
+  return apiFetch("/api/v1/posts", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function updatePost(
+  id: string,
+  input: UpdatePostInput,
+): Promise<Post> {
+  return apiFetch(`/api/v1/posts/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function deletePost(id: string): Promise<void> {
+  return apiFetch(`/api/v1/posts/${id}`, { method: "DELETE" });
+}
+
+export async function likePost(id: string): Promise<{ likeCount: number }> {
+  return apiFetch(`/api/v1/posts/${id}/like`, { method: "POST" });
+}
+```
+
+- [ ] **Step 3: API 클라이언트 수동 테스트**
+
+개발 서버(`npm run dev`)가 실행 중인 상태에서, 브라우저 콘솔에서:
+
+```javascript
+fetch("http://localhost:8000/api/v1/posts")
+  .then(r => r.json())
+  .then(console.log)
+```
+
+Expected: msw가 가로채서 mock 데이터 반환 (items 배열 20개)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add frontend/src/lib/
+git commit -m "feat(fe): FE-1 API 클라이언트 레이어 (fetch wrapper, posts API)"
+```
+
+---
+
+## Task 4: Naive 게시글 목록 페이지
+
+**Files:**
+- Create: `frontend/src/components/posts/PostCard.tsx`
+- Create: `frontend/src/components/posts/PostList.tsx`
+- Modify: `frontend/src/app/page.tsx`
+
+**핵심 의도**: 의도적으로 비최적화. React.memo 없음, useCallback 없음, 모든 컴포넌트가 부모 re-render 시 함께 re-render됨. FE-2에서 이 문제를 측정한다.
+
+- [ ] **Step 1: PostCard 컴포넌트 작성 (naive)**
+
+`src/components/posts/PostCard.tsx` 생성:
+
+```typescript
+"use client";
+
+import type { PostListItem } from "@/types/post";
+import Link from "next/link";
+
+// 의도적으로 React.memo 없음 — FE-2에서 re-render 측정 예정
+export function PostCard({ post }: { post: PostListItem }) {
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 transition-colors">
+      <Link href={`/posts/${post.id}`}>
+        <h2 className="text-lg font-semibold text-gray-900 mb-1 hover:text-blue-600">
+          {post.title}
+        </h2>
+      </Link>
+      <div className="flex items-center gap-4 text-sm text-gray-500">
+        <span>{post.author}</span>
+        <span>조회 {post.viewCount.toLocaleString()}</span>
+        <span>좋아요 {post.likeCount}</span>
+        <span>댓글 {post.commentCount}</span>
+        <span>{new Date(post.createdAt).toLocaleDateString("ko-KR")}</span>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: PostList 컴포넌트 작성 (naive)**
+
+`src/components/posts/PostList.tsx` 생성:
+
+```typescript
+"use client";
+
+import { useState, useEffect } from "react";
+import { fetchPosts } from "@/lib/api/posts";
+import type { PostListItem } from "@/types/post";
+import { PostCard } from "./PostCard";
+
+// 의도적으로 naive: 전체 fetch, OFFSET 페이지네이션, 캐싱 없음
+export function PostList() {
+  const [posts, setPosts] = useState<PostListItem[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const pageSize = 20;
+  const totalPages = Math.ceil(total / pageSize);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetchPosts(page, pageSize)
+      .then((res) => {
+        setPosts(res.items);
+        setTotal(res.total);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "오류가 발생했습니다");
+      })
+      .finally(() => setLoading(false));
+  }, [page]); // page 변경마다 전체 목록 재요청 (naive)
+
+  if (loading) return <div className="text-center py-8">로딩 중...</div>;
+  if (error) return <div className="text-center py-8 text-red-500">{error}</div>;
+
+  return (
+    <div>
+      <div className="flex flex-col gap-3">
+        {posts.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
+      </div>
+
+      {/* OFFSET 페이지네이션 (naive) */}
+      <div className="flex justify-center items-center gap-2 mt-8">
+        <button
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page === 1}
+          className="px-4 py-2 border rounded disabled:opacity-50"
+        >
+          이전
+        </button>
+        <span className="text-sm text-gray-600">
+          {page} / {totalPages} 페이지 (총 {total.toLocaleString()}개)
+        </span>
+        <button
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page === totalPages}
+          className="px-4 py-2 border rounded disabled:opacity-50"
+        >
+          다음
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: 게시글 목록 페이지 작성**
+
+`src/app/page.tsx`를 다음으로 교체:
+
+```typescript
+import Link from "next/link";
+import { PostList } from "@/components/posts/PostList";
+
+export default function HomePage() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">극한 게시판</h1>
+        <Link
+          href="/posts/new"
+          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
+        >
+          글 작성
+        </Link>
+      </div>
+      <PostList />
+    </main>
+  );
+}
+```
+
+- [ ] **Step 4: 브라우저에서 목록 동작 확인**
+
+```bash
+npm run dev
+```
+
+`http://localhost:3000` 접속 → 게시글 20개 목록, 페이지네이션 동작 확인
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add frontend/src/components/ frontend/src/app/page.tsx
+git commit -m "feat(fe): FE-1 naive 게시글 목록 (OFFSET 페이지네이션, 캐싱 없음)"
+```
+
+---
+
+## Task 5: 게시글 상세 + 작성 페이지
+
+**Files:**
+- Create: `frontend/src/components/posts/PostDetail.tsx`
+- Create: `frontend/src/components/posts/PostForm.tsx`
+- Create: `frontend/src/app/posts/[id]/page.tsx`
+- Create: `frontend/src/app/posts/new/page.tsx`
+
+- [ ] **Step 1: PostDetail 컴포넌트 작성**
+
+`src/components/posts/PostDetail.tsx` 생성:
+
+```typescript
+"use client";
+
+import { useState, useEffect } from "react";
+import { fetchPost, likePost, deletePost } from "@/lib/api/posts";
+import type { Post } from "@/types/post";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export function PostDetail({ id }: { id: string }) {
+  const [post, setPost] = useState<Post | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [liking, setLiking] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetchPost(id)
+      .then(setPost)
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "오류가 발생했습니다");
+      })
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  async function handleLike() {
+    if (!post) return;
+    setLiking(true);
+    try {
+      const result = await likePost(post.id);
+      setPost((prev) => prev ? { ...prev, likeCount: result.likeCount } : null);
+    } catch {
+      alert("좋아요 실패");
+    } finally {
+      setLiking(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!post || !confirm("삭제하시겠습니까?")) return;
+    try {
+      await deletePost(post.id);
+      router.push("/");
+    } catch {
+      alert("삭제 실패");
+    }
+  }
+
+  if (loading) return <div className="text-center py-8">로딩 중...</div>;
+  if (error) return <div className="text-center py-8 text-red-500">{error}</div>;
+  if (!post) return <div className="text-center py-8">게시글을 찾을 수 없습니다</div>;
+
+  return (
+    <article className="max-w-4xl mx-auto px-4 py-8">
+      <div className="mb-6">
+        <Link href="/" className="text-blue-600 hover:underline text-sm">
+          ← 목록으로
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-bold mb-4">{post.title}</h1>
+
+      <div className="flex items-center gap-4 text-sm text-gray-500 mb-6 pb-4 border-b">
+        <span>{post.author}</span>
+        <span>조회 {post.viewCount.toLocaleString()}</span>
+        <span>{new Date(post.createdAt).toLocaleDateString("ko-KR")}</span>
+      </div>
+
+      <div className="prose max-w-none mb-8 whitespace-pre-wrap">
+        {post.content}
+      </div>
+
+      <div className="flex gap-4">
+        <button
+          onClick={handleLike}
+          disabled={liking}
+          className="flex items-center gap-2 px-4 py-2 border rounded-lg hover:bg-gray-50 disabled:opacity-50"
+        >
+          👍 좋아요 {post.likeCount}
+        </button>
+        <Link
+          href={`/posts/${post.id}/edit`}
+          className="px-4 py-2 border rounded-lg hover:bg-gray-50"
+        >
+          수정
+        </Link>
+        <button
+          onClick={handleDelete}
+          className="px-4 py-2 border border-red-300 text-red-600 rounded-lg hover:bg-red-50"
+        >
+          삭제
+        </button>
+      </div>
+    </article>
+  );
+}
+```
+
+- [ ] **Step 2: PostForm 컴포넌트 작성 (작성/수정 공용)**
+
+`src/components/posts/PostForm.tsx` 생성:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import { createPost, updatePost } from "@/lib/api/posts";
+import { useRouter } from "next/navigation";
+import type { Post, CreatePostInput } from "@/types/post";
+
+interface PostFormProps {
+  mode: "create" | "edit";
+  post?: Post;
+}
+
+export function PostForm({ mode, post }: PostFormProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState(post?.title ?? "");
+  const [content, setContent] = useState(post?.content ?? "");
+  const [author, setAuthor] = useState(post?.author ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim() || !content.trim()) {
+      setError("제목과 내용을 입력해주세요");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      if (mode === "create") {
+        const input: CreatePostInput = { title, content, author: author || "익명" };
+        const created = await createPost(input);
+        router.push(`/posts/${created.id}`);
+      } else if (post) {
+        await updatePost(post.id, { title, content });
+        router.push(`/posts/${post.id}`);
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "오류가 발생했습니다");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-6">
+        {mode === "create" ? "글 작성" : "글 수정"}
+      </h1>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-300 text-red-600 rounded">
+          {error}
+        </div>
+      )}
+
+      {mode === "create" && (
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            작성자
+          </label>
+          <input
+            type="text"
+            value={author}
+            onChange={(e) => setAuthor(e.target.value)}
+            placeholder="작성자 이름"
+            className="w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      )}
+
+      <div className="mb-4">
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          제목
+        </label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="제목을 입력하세요"
+          className="w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+        />
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          내용
+        </label>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="내용을 입력하세요"
+          rows={10}
+          className="w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+          required
+        />
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? "저장 중..." : mode === "create" ? "작성" : "수정"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="border px-6 py-2 rounded-lg hover:bg-gray-50"
+        >
+          취소
+        </button>
+      </div>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 3: 상세 페이지 작성**
+
+`src/app/posts/[id]/page.tsx` 생성:
+
+```typescript
+import { PostDetail } from "@/components/posts/PostDetail";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function PostDetailPage({ params }: Props) {
+  const { id } = await params;
+  return <PostDetail id={id} />;
+}
+```
+
+- [ ] **Step 4: 작성 페이지 작성**
+
+`src/app/posts/new/page.tsx` 생성:
+
+```typescript
+import { PostForm } from "@/components/posts/PostForm";
+
+export default function NewPostPage() {
+  return <PostForm mode="create" />;
+}
+```
+
+- [ ] **Step 5: 수정 페이지 추가**
+
+`src/app/posts/[id]/edit/page.tsx` 생성:
+
+```typescript
+import { PostForm } from "@/components/posts/PostForm";
+import { fetchPost } from "@/lib/api/posts";
+import { notFound } from "next/navigation";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+// Server Component — params를 async로 처리 (Next.js 16)
+export default async function EditPostPage({ params }: Props) {
+  const { id } = await params;
+  let post;
+  try {
+    post = await fetchPost(id);
+  } catch {
+    notFound();
+  }
+  return <PostForm mode="edit" post={post} />;
+}
+```
+
+> **주의**: msw는 브라우저에서만 동작한다. Server Component에서 `fetchPost`를 직접 호출하면 msw가 가로채지 않는다. FE-1에서는 수정 페이지를 Client Component로 래핑하는 방식 대신, `PostForm` 컴포넌트가 Client Component이므로 `mode="edit"`와 함께 초기 데이터를 props로 주입할 수 없다. 해결: `EditPostPage`를 Client Component로 전환하거나, 수정 폼에서 직접 fetch하도록 변경한다.
+>
+> **FE-1에서의 실용적 접근**: `src/app/posts/[id]/edit/page.tsx`를 Client Component로 작성:
+
+```typescript
+"use client";
+
+import { useState, useEffect, use } from "react";
+import { fetchPost } from "@/lib/api/posts";
+import type { Post } from "@/types/post";
+import { PostForm } from "@/components/posts/PostForm";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default function EditPostPage({ params }: Props) {
+  const { id } = use(params);
+  const [post, setPost] = useState<Post | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchPost(id).then(setPost).finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <div className="text-center py-8">로딩 중...</div>;
+  if (!post) return <div className="text-center py-8">게시글을 찾을 수 없습니다</div>;
+
+  return <PostForm mode="edit" post={post} />;
+}
+```
+
+- [ ] **Step 6: 전체 CRUD 동작 확인**
+
+브라우저에서 순서대로 확인:
+1. `http://localhost:3000` → 목록 20개 표시
+2. 게시글 클릭 → 상세 페이지 이동, 조회수 증가
+3. 좋아요 버튼 클릭 → 카운트 증가
+4. 글 작성 → 목록에 추가 확인
+5. 수정 → 내용 변경 확인
+6. 삭제 → 목록에서 제거 확인
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add frontend/src/components/posts/PostDetail.tsx \
+        frontend/src/components/posts/PostForm.tsx \
+        frontend/src/app/posts/
+git commit -m "feat(fe): FE-1 게시글 상세/작성/수정/삭제 페이지 (naive CRUD)"
+```
+
+---
+
+## Task 6: 기준값 측정 (Baseline Benchmark)
+
+**Files:**
+- Create: `frontend/benchmarks/fe-phase-01-baseline.md`
+
+**목적**: FE-2에서 병목을 체험하고 FE-3~에서 최적화 후 비교할 기준값 확보.
+
+- [ ] **Step 1: Lighthouse 기준값 측정**
+
+```bash
+# 프로덕션 빌드로 측정 (개발 서버는 번들이 최적화되지 않아 결과 왜곡)
+npm run build
+npm run start
+```
+
+Chrome에서 `http://localhost:3000` 열고 DevTools → Lighthouse → Performance 실행.
+
+결과를 기록: Performance 점수, LCP, TBT, CLS 수치
+
+- [ ] **Step 2: React Profiler 기준값 측정**
+
+개발 서버(`npm run dev`)에서:
+1. React DevTools 설치 (Chrome 확장)
+2. Profiler 탭 → Record 시작
+3. 페이지 목록 렌더링 → Record 중지
+4. PostList, PostCard 렌더링 시간 기록
+
+- [ ] **Step 3: 기준값 문서 작성**
+
+`frontend/benchmarks/fe-phase-01-baseline.md` 생성:
+
+```markdown
+# FE-1 기준값 (Baseline)
+
+측정일: 2026-04-07
+환경: MacBook (로컬), Chrome, 3G 없음
+
+## Lighthouse (프로덕션 빌드)
+
+| 지표 | 값 |
+|------|-----|
+| Performance 점수 | [측정값] |
+| LCP | [측정값] |
+| TBT | [측정값] |
+| CLS | [측정값] |
+
+## React Profiler (개발 서버)
+
+| 컴포넌트 | 렌더링 시간 | 렌더링 횟수 |
+|---------|-----------|-----------|
+| PostList | [측정값] | [측정값] |
+| PostCard (×20) | [측정값] | [측정값] |
+
+## 번들 크기 (빌드 결과)
+
+| 파일 | 크기 |
+|------|------|
+| page.js (메인) | [측정값] |
+| 전체 JS | [측정값] |
+
+## 메모리 사용량
+
+초기 로딩 후: [측정값] MB
+
+---
+
+다음 측정: FE-2 (10만건 렌더링 시 병목 체험)
+```
+
+- [ ] **Step 4: 최종 커밋**
+
+```bash
+git add frontend/benchmarks/
+git commit -m "feat(fe): FE-1 기준값 측정 완료 (Lighthouse, Profiler, 번들 크기)"
+```
+
+---
+
+## Phase 완료 체크리스트
+
+- [ ] `npm run dev` 실행 시 msw 정상 동작
+- [ ] 게시글 목록 → 상세 → 작성 → 수정 → 삭제 CRUD 전체 동작
+- [ ] TypeScript 에러 없음 (`npx tsc --noEmit`)
+- [ ] ESLint 에러 없음 (`npm run lint`)
+- [ ] `benchmarks/fe-phase-01-baseline.md`에 기준값 기록 완료
+- [ ] 커밋 4개 이상 완료
+
+## 다음 Phase
+
+→ **FE-2**: msw mock 데이터를 10만건으로 늘리고, 목록 전체를 렌더링하여 브라우저 프리징을 체험한다.
+
+**학습 예습**: React Reconciliation은 O(n)이다. 10만개의 DOM 노드가 생성될 때 Layout/Paint 비용이 어떻게 되는지 미리 생각해보자.

--- a/docs/superpowers/specs/2026-04-07-extreme-frontend-design.md
+++ b/docs/superpowers/specs/2026-04-07-extreme-frontend-design.md
@@ -1,0 +1,292 @@
+# 극한 프론트엔드 성능 챌린지 — 설계 문서
+
+## 목표
+
+백엔드 극한 트래픽 게시판(1M CCU / 1M RPS)과 협업하여, 프론트엔드에서도 극한 상황의 성능 문제를 체험하고 최적화하는 학습 프로젝트.
+
+**핵심 원칙**: naive 구현 → 병목 체험 → 최적화 → 벤치마크 증명
+
+## 기술 스택
+
+| 구분 | 선택 | 이유 |
+|------|------|------|
+| 프레임워크 | Next.js (App Router) | SSR/SSG/ISR, Server Components, Edge Runtime |
+| 언어 | TypeScript | 타입 안전성, 리팩토링 용이 |
+| 스타일링 | Tailwind CSS | 런타임 비용 없음, 빠른 개발 |
+| 데이터 페칭 | TanStack Query | 서버 상태 캐싱, Optimistic Update |
+| 상태 관리 | Zustand | 경량, 클라이언트 상태 전용 |
+| 테스트 | Playwright + Lighthouse CI | E2E + 성능 자동 측정 |
+
+## Phase 구조
+
+백엔드 12 Phase에 동기화 + 프론트엔드 전용 3개 Phase 삽입 (★ 표시).
+
+총 **13 Phase, 52 Task**.
+
+### Phase 매핑 테이블
+
+| Phase | BE 대응 | 프론트엔드 주제 | 핵심 챌린지 |
+|-------|---------|---------------|-----------|
+| FE-1 | BE-1 Foundation | 프로젝트 셋업 + Naive UI | Next.js 기본 CRUD, 의도적 비최적화 |
+| FE-2 | BE-2 Bottleneck | 렌더링 병목 체험 | 10만건 렌더링, Re-render 폭풍, Profiler |
+| FE-3 | BE-3 DB Opt | 리스트 최적화 | 커서 무한 스크롤, memo, Intersection Observer |
+| FE-4 | BE-4 Redis Cache | 데이터 페칭 + 캐싱 | TanStack Query, SWR 패턴, Optimistic Update |
+| ★ FE-5 | (전용) | 대량 렌더링 극한 | 가상 스크롤, 10만건+, DOM 재사용, rAF |
+| FE-6 | BE-5~6 Counter+Idem | 동시성 UI 패턴 | Race Condition, 멱등성 키, AbortController |
+| FE-7 | BE-7 CQRS+Events | 상태 관리 + Polling | Read/Write 상태 분리, Smart Polling |
+| FE-8 | BE-8 Image Upload | 이미지 업로드 UX | Presigned URL, 클라이언트 압축, Lazy Loading |
+| ★ FE-9 | (전용) | 네트워크 극한 | Service Worker, 오프라인, 번들 최적화 |
+| FE-10 | BE-9 Monitoring | 프론트엔드 모니터링 | Web Vitals, Memory Leak, 성능 대시보드 |
+| FE-11 | BE-10~11 Load+Chaos | 스트레스 테스트 | Lighthouse CI, 장애 시뮬레이션, Skeleton UI |
+| ★ FE-12 | (전용) | 메모리/성능 극한 | Heap Snapshot, GC 압박, Long Task 분석 |
+| FE-13 | BE-12 Cloud | 프로덕션 배포 + CDN | Vercel, ISR, CDN 캐싱, 최종 리포트 |
+
+---
+
+## Phase 세부 설계
+
+### FE-1: 프로젝트 셋업 + Naive UI
+
+**학습 키워드**: Next.js App Router, SSR vs CSR, Hydration, React Rendering Pipeline (Reconciliation → Commit)
+
+> **참고**: 백엔드 Phase 1이 완료될 때까지 msw(Mock Service Worker)로 개발 진행, 완료 후 실제 API로 전환.
+
+**태스크**:
+- **Task 1**: Next.js 프로젝트 초기화 — App Router, TypeScript strict, Tailwind, ESLint, msw 설정
+- **Task 2**: 게시글 목록 페이지 — 의도적 naive 구현 (전체 데이터 한번에 fetch, OFFSET 페이지네이션, 모든 컴포넌트 re-render 허용)
+- **Task 3**: 게시글 상세/작성/수정 페이지 — 기본 CRUD UI
+- **Task 4**: API 연동 레이어 — fetch wrapper, 에러 핸들링 기본 구조
+
+**벤치마크**: 초기 Lighthouse 점수 기록, React Profiler 렌더링 시간 기준값
+
+---
+
+### FE-2: 렌더링 병목 체험
+
+**학습 키워드**: React Reconciliation O(n) diffing, Virtual DOM 비용, JavaScript 메인 스레드 블로킹, Long Task, Chrome DevTools Performance 탭
+
+**핵심 질문**: "왜 10만건을 한번에 렌더링하면 안 되는가?" → DOM 노드 수 × Layout/Paint 비용, 메모리 사용량
+
+**태스크**:
+- **Task 5**: 시드 데이터 10만건 목록 렌더링 → 브라우저 프리징 체험
+- **Task 6**: React Profiler로 불필요 re-render 시각화, Performance 탭으로 Long Task 측정
+- **Task 7**: benchmark_compare.md 작성 — 1천/1만/10만건 렌더링 시간 비교
+
+**벤치마크**: 건수별 렌더링 시간, 메모리 사용량, Long Task 횟수
+
+---
+
+### FE-3: 리스트 최적화
+
+**학습 키워드**: 커서 기반 페이지네이션 UI, Intersection Observer API (vs scroll event), React.memo / useMemo / useCallback, Referential Equality
+
+**태스크**:
+- **Task 8**: 무한 스크롤 — Intersection Observer + 커서 페이지네이션
+- **Task 9**: React.memo 적용, 전후 Profiler 비교
+- **Task 10**: Key 전략 — index key vs stable key 성능 차이 벤치마크
+
+**벤치마크**: FE-2 대비 렌더링 시간, 스크롤 FPS
+
+---
+
+### FE-4: 데이터 페칭 + 캐싱 전략
+
+**학습 키워드**: Stale-While-Revalidate 패턴, TanStack Query 캐시 (Query Key, gcTime, staleTime), Optimistic Update + 롤백, HTTP Cache-Control vs 앱 레벨 캐시
+
+**태스크**:
+- **Task 11**: TanStack Query 도입, useInfiniteQuery로 무한 스크롤 리팩토링
+- **Task 12**: 캐시 전략 — 목록(stale 30s), 상세(stale 5m), 카운터(stale 0s)
+- **Task 13**: Optimistic Update — 좋아요 즉시 반영 → 실패 시 롤백
+- **Task 14**: 캐시 히트율 측정, API 요청 수 전후 비교
+
+**벤치마크**: API 호출 수 전후 비교, 체감 응답 속도(TTI)
+
+---
+
+### ★ FE-5: 대량 렌더링 극한 챌린지
+
+**학습 키워드**: 가상 스크롤(Virtualization), Overscan, DOM 재사용 풀, requestAnimationFrame, 브라우저 렌더링 파이프라인 (Style → Layout → Paint → Composite), GPU 가속 (transform/opacity), will-change
+
+**태스크**:
+- **Task 15**: 가상 스크롤 직접 구현 — 라이브러리 없이 (containerHeight, itemHeight, startIndex/endIndex, transform: translateY)
+- **Task 16**: 가변 높이 아이템 가상 스크롤 — 높이 추정 + 실측 보정 (ResizeObserver)
+- **Task 17**: 라이브러리 비교 — 직접 구현 vs @tanstack/react-virtual vs react-window
+- **Task 18**: 극한 테스트 — 100만건 리스트, 60fps 유지 목표, Memory 측정
+
+**벤치마크**: naive(FE-2) vs 무한스크롤(FE-3) vs 가상화(FE-5) 3단계 비교 리포트
+
+---
+
+### FE-6: 동시성 UI 패턴
+
+**학습 키워드**: Optimistic Update 심화, Race Condition (stale closure, 요청 순서 역전), AbortController, 멱등성 키 (UUID v4), 디바운싱/쓰로틀링
+
+**태스크**:
+- **Task 19**: 좋아요 Race Condition 재현 — 빠른 연타 시 카운트 불일치
+- **Task 20**: AbortController + 멱등성 키, 요청 순서 보장 (시퀀스 넘버)
+- **Task 21**: 디바운스 검색 + 쓰로틀 스크롤 — 직접 구현 후 성능 측정
+- **Task 22**: 에러 시 롤백 UI — Toast 실패 알림 + 자동 복구
+
+**벤치마크**: 100회 연타 카운트 정확도, 불필요 API 호출 수 비교
+
+---
+
+### FE-7: 상태 관리 + Smart Polling
+
+**학습 키워드**: CQRS 프론트엔드 관점 — Read State(서버 캐시) vs Write State(로컬 mutation), Smart Polling, Document Visibility API, 상태 관리 계층 (서버 vs 클라이언트 vs UI)
+
+**태스크**:
+- **Task 23**: TanStack Query refetchOnWindowFocus, refetchInterval로 Smart Polling
+- **Task 24**: Document Visibility API — 비활성 탭 폴링 중지, 복귀 시 즉시 갱신
+- **Task 25**: 상태 분리 설계 — 서버 상태(TanStack Query), 클라이언트 상태(Zustand, Context 없이)
+- **Task 26**: 멀티 탭 데이터 일관성 검증
+
+**벤치마크**: 폴링 제거 전후 네트워크 요청 수, CPU/배터리 영향
+
+---
+
+### FE-8: 이미지 업로드 UX
+
+**학습 키워드**: Presigned URL 업로드 흐름, File API + Blob, Canvas API 이미지 압축, OffscreenCanvas, Progressive Image Loading, Lazy Loading (loading="lazy" vs Intersection Observer)
+
+**태스크**:
+- **Task 27**: Presigned URL 업로드 — 파일 선택 → URL 발급 → XHR progress 이벤트
+- **Task 28**: 이미지 미리보기 — URL.createObjectURL, 드래그앤드롭
+- **Task 29**: 클라이언트 이미지 압축 — Canvas API 리사이즈/품질 조절
+- **Task 30**: Lazy Loading — Intersection Observer, placeholder blur
+
+**벤치마크**: 업로드 시간 (직접 vs 서버 경유), 압축 전후 용량/품질, LCP
+
+---
+
+### ★ FE-9: 네트워크 극한 챌린지
+
+**학습 키워드**: Service Worker 라이프사이클, Cache API 전략 (Cache First, Network First, SWR), 번들 분석, Code Splitting (dynamic import, React.lazy), Tree Shaking, HTTP/2, Resource Hints (preload, prefetch, preconnect)
+
+**태스크**:
+- **Task 31**: 번들 분석 — @next/bundle-analyzer로 크기 측정, 큰 의존성 식별
+- **Task 32**: Code Splitting — 페이지별 dynamic import, 에디터/이미지 lazy loading
+- **Task 33**: Service Worker 직접 구현 — API 캐싱(Network First), 정적 자원(Cache First)
+- **Task 34**: 오프라인 모드 — 캐시 게시글 표시, 오프라인 작성 → 동기화 큐
+- **Task 35**: 3G 시뮬레이션 — Chrome Throttling으로 극한 네트워크 UX 검증
+
+**벤치마크**: 번들 크기 전후, 3G FCP/LCP, 오프라인→온라인 동기화 성공률
+
+---
+
+### FE-10: 프론트엔드 모니터링
+
+**학습 키워드**: Core Web Vitals (LCP, INP, CLS), PerformanceObserver API, Long Animation Frame API, Memory API, Error Boundary, 프론트엔드 에러 수집 (window.onerror, unhandledrejection)
+
+**태스크**:
+- **Task 36**: Web Vitals 수집 — web-vitals + 커스텀 PerformanceObserver
+- **Task 37**: 성능 대시보드 — 실시간 Web Vitals, 메모리, Long Task 시각화
+- **Task 38**: Error Boundary 계층 — 페이지/컴포넌트/API 레벨 분리, Fallback UI
+- **Task 39**: 에러 리포팅 — 글로벌 핸들러, 구조화된 에러 리포트
+
+**벤치마크**: 전 Phase 최적화 전후 Web Vitals 변화 리포트
+
+---
+
+### FE-11: 프론트엔드 스트레스 테스트
+
+**학습 키워드**: Lighthouse CI 자동화, Playwright E2E 성능 테스트, 네트워크 장애 시뮬레이션, Graceful Degradation vs Progressive Enhancement, Skeleton UI
+
+**태스크**:
+- **Task 40**: Lighthouse CI — GitHub Actions PR별 자동 성능 측정
+- **Task 41**: Playwright 성능 시나리오 — 100개 스크롤, 이미지 로딩, 좋아요 연타
+- **Task 42**: 장애 시뮬레이션 — API 타임아웃, 500 에러, 네트워크 끊김 UX
+- **Task 43**: Skeleton UI — 모든 로딩 상태에 Skeleton + Suspense Boundary
+
+**벤치마크**: Lighthouse History, 장애 시 UX 연속성
+
+---
+
+### ★ FE-12: 메모리/성능 극한 챌린지
+
+**학습 키워드**: V8 GC (Minor/Major GC, Generational), Heap Snapshot (Retained Size vs Shallow Size), Memory Leak 패턴 (이벤트 리스너, 클로저, 타이머, detached DOM), Long Task/Long Animation Frame
+
+**태스크**:
+- **Task 44**: Memory Leak 생성 → 탐지 → 수정 (이벤트 리스너, setInterval, detached DOM)
+- **Task 45**: Heap Snapshot 비교 — 페이지 이동 전후 메모리 증가 분석
+- **Task 46**: GC 압박 테스트 — 대량 객체 생성/해제, GC pause 측정
+- **Task 47**: 성능 리포트 자동화 — 전 Phase 벤치마크 종합 리포트 생성
+
+**벤치마크**: 10분 연속 사용 메모리 증가량, GC pause 빈도, 종합 리포트
+
+---
+
+### FE-13: 프로덕션 배포 + CDN
+
+**학습 키워드**: Vercel 배포, Edge Runtime vs Node.js Runtime, ISR, CDN 캐싱 (s-maxage, stale-while-revalidate), next/image 최적화 (WebP/AVIF), 보안 헤더 (CSP, HSTS)
+
+**태스크**:
+- **Task 48**: Vercel 배포 — 환경변수, 빌드 설정
+- **Task 49**: ISR 적용 — 게시글 상세 ISR, revalidate 전략
+- **Task 50**: 이미지 최적화 — next/image + CDN, WebP 자동 변환
+- **Task 51**: 최종 성능 리포트 — Phase 1 vs Phase 13 전체 비교
+- **Task 52**: 비용 분석 — Vercel 무료 티어, CDN 비용, 총 운영비
+
+**벤치마크**: naive(FE-1) vs 최종(FE-13) 전체 성능 비교 리포트
+
+---
+
+## 학습 방식
+
+각 Phase는 백엔드와 동일한 구조를 따름:
+
+1. **학습 섹션** — 핵심 개념, 원리, "왜 이렇게 하는가"
+2. **구현 섹션** — naive → 최적화 순서로 코드 작성
+3. **벤치마크 섹션** — 전후 수치 비교로 개선 증명
+4. **키워드/면접 질문** — 해당 Phase 관련 핵심 키워드와 예상 면접 질문
+
+## 프로젝트 디렉토리 구조 (예상)
+
+```
+frontend/
+├── src/
+│   ├── app/                    # Next.js App Router 페이지
+│   │   ├── layout.tsx
+│   │   ├── page.tsx            # 메인 (게시글 목록)
+│   │   ├── posts/
+│   │   │   ├── [id]/page.tsx   # 게시글 상세
+│   │   │   └── new/page.tsx    # 게시글 작성
+│   │   └── dashboard/page.tsx  # 성능 대시보드 (FE-10)
+│   ├── components/
+│   │   ├── posts/              # 게시글 관련 컴포넌트
+│   │   ├── common/             # 공통 UI (Skeleton, ErrorBoundary 등)
+│   │   └── dashboard/          # 성능 대시보드 컴포넌트
+│   ├── hooks/                  # 커스텀 훅
+│   ├── lib/                    # 유틸리티, API 클라이언트
+│   │   ├── api/                # API fetch 함수
+│   │   ├── cache/              # 캐시 전략
+│   │   └── performance/        # 성능 측정 유틸
+│   ├── store/                  # Zustand 스토어
+│   └── workers/                # Service Worker, Web Worker
+├── public/
+├── tests/
+│   ├── e2e/                    # Playwright E2E
+│   └── performance/            # 성능 벤치마크 스크립트
+├── benchmarks/                 # Phase별 벤치마크 결과
+├── next.config.ts
+├── tailwind.config.ts
+├── tsconfig.json
+└── package.json
+```
+
+## 백엔드 협업 포인트
+
+| Phase | 프론트엔드 | 백엔드 의존성 |
+|-------|-----------|-------------|
+| FE-1 | CRUD UI | BE-1 API 엔드포인트 |
+| FE-3 | 커서 페이지네이션 | BE-3 커서 API |
+| FE-4 | 캐싱 전략 | BE-4 Cache-Control 헤더 |
+| FE-6 | 멱등성 키 | BE-6 Idempotency API |
+| FE-8 | Presigned URL | BE-8 URL 발급 API |
+| FE-13 | CDN 배포 | BE-12 클라우드 인프라 |
+
+## 비용 전략
+
+- Phase 1~12: 로컬 개발 ($0) — 백엔드 Docker Compose 활용
+- Phase 13: Vercel Hobby (무료) + 백엔드 AWS ($43~70)
+- **총 예상 비용: $0~$70 (백엔드 포함)**


### PR DESCRIPTION
## Background

백엔드 극한 트래픽 챌린지(12 Phase)에 대응하는 프론트엔드 챌린지의
전체 설계 문서와 FE-1 상세 구현 계획을 문서화한다.
"naive 구현 → 병목 체험 → 최적화 → 벤치마크 증명" 루프를 13 Phase / 52 Task에 걸쳐 진행.

## 구현 내용

1. 프론트엔드 설계 문서 추가 (`specs/2026-04-07-extreme-frontend-design.md`)
   - 기술 스택 확정: Next.js 16, TypeScript 5.x, Tailwind CSS 4.x, TanStack Query, Zustand, msw, Playwright
   - BE 12 Phase 동기화 + FE 전용 3 Phase(대량 렌더링 극한, 네트워크 극한, 메모리 극한) 삽입
   - Phase별 학습 키워드, 핵심 챌린지, 벤치마크 기준 정의
2. 마스터 구현 계획 추가 (`plans/2026-04-07-extreme-frontend-implementation.md`)
   - 전체 13 Phase Task 목록 및 실행 순서
   - 백엔드 협업 포인트 명시 (커서 API, Presigned URL, 멱등성 키 등)
3. FE-1 상세 구현 계획 추가 (`plans/fe-phases/fe-phase-01-foundation.md`)
   - Task 1~4 단계별 체크리스트 및 검증 기준
   - Next.js 16 프로젝트 셋업, msw 모킹, 의도적 naive CRUD 구현 가이드

## 설계 결정 & 트레이드오프

| 결정 | 이유 | 포기한 대안 |
|------|------|------------|
| Next.js 16 채택 | 최신 버전 학습, App Router 안정화 | Next.js 15 |
| FE Phase 13개 (BE 12 + 전용 3) | 프론트엔드 고유 병목(가상화, SW, 메모리)은 별도 Phase 필요 | BE Phase만 따라가기 |
| msw로 백엔드 의존성 제거 | BE Phase 1 완료 전에도 FE 개발 병렬 진행 가능 | BE 완료 대기 |

## 성능 측정

N/A (문서 추가)

## 참고 자료

- `docs/superpowers/specs/2026-04-07-extreme-frontend-design.md`

## 코멘트

FE-2~13 상세 계획은 각 Phase 시작 시 별도 PR로 추가 예정.