### PR TITLE
feat: Phase 구현 하네스 스킬 추가

### DIFF
--- a/.agents/skills/commit/skill.md
+++ b/.agents/skills/commit/skill.md
@@ -1,0 +1,129 @@
+---
+name: commit
+description: Convention-based commits. Use when the user asks to commit (e.g. "커밋해줘", "commit해줘", "변경사항 저장해줘").
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*), Bash(git stash:*), Bash(git pull:*), Bash(git checkout:*), Bash(git switch:*), Bash(git branch:*), Bash(git symbolic-ref:*)
+---
+
+# Commit - Convention-based Commits
+
+Analyzes changes and creates commits following the project convention.
+
+## Current Git Context
+
+Current git status: !git status
+Current git diff (staged and unstaged changes): !git diff HEAD
+Current branch: !git branch --show-current
+Recent commits: !git log --oneline -10
+
+---
+
+## Base Branch Detection
+
+Determine the base branch using this priority:
+1. If the project AGENTS.md specifies a main/base branch, use that
+2. Try `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'`
+3. Default: `main`
+
+---
+
+## Commit Message Convention
+
+### Format
+
+```
+type: summary of changes (max 50 chars)
+
+- detail 1
+- detail 2
+```
+
+First line is a concise summary; after a blank line, list details with bullets (`-`).
+
+### Type Rules
+| Type | When to use |
+|------|------------|
+| `feat` | New feature or screen |
+| `fix` | Bug fix |
+| `refactor` | Code restructure without behavior change |
+| `style` | UI/CSS only changes |
+| `chore` | Config, deps, tooling, generated files |
+| `test` | Test files only |
+| `docs` | Documentation only |
+
+### Seven Rules (한국어 적용)
+
+1. Separate subject from body with a **blank line**
+2. Limit subject line to **50 characters**
+3. Type prefix in **lowercase** (한국어에는 대소문자 개념이 없으므로, 원본 "Capitalize" 규칙은 타입 접두어 소문자 유지로 대체)
+4. **No period** at end of subject line
+5. Write subject in **imperative mood** (e.g. "추가", "수정", "제거" — not "추가했음", "수정하는 중")
+6. Wrap body at **72 characters**
+7. Body explains **what** and **why**, not *how*
+
+### 프로젝트 규칙
+
+- **커밋 메시지는 한국어로 작성** (type prefix remains English)
+
+### Commit Grouping Strategy
+
+**Group by feature unit**, not by code layer (implementation vs test).
+
+- **One commit = one complete feature unit** — implementation code + its tests together
+- If the same type repeats 3+ times in a row, the grouping is wrong (e.g. `test:` x3)
+- Use `test:` type **only** when adding tests to existing code or changing test infrastructure
+
+**Grouping example:**
+```
+# Good — 기능 단위로 분리, 구현 + 테스트 포함
+feat: 관리자 활성 상태 변경 구현
+feat: 관리자 일괄 수정 API 구현
+feat: 관리자 일괄 삭제 API 구현
+
+# Bad — 코드 레이어로 분리, 구현/테스트 따로
+feat: 어드민 수정 API 확장 및 일괄 수정/삭제 구현
+test: 활성 상태 변경 테스트
+test: 일괄 수정 테스트
+test: 일괄 삭제 테스트
+```
+
+### Examples
+```
+feat: 관리자 계정 생성 구현
+
+- AdminService.create_admin() 메서드 구현
+- CreateAdminRequest/Response DTO 추가
+- POST /api/v1/admins 엔드포인트 등록
+- 생성 성공/실패 테스트 추가
+```
+
+```
+fix: reissue 시 Admin 상태 검증
+
+- INACTIVE 상태 관리자 토큰 재발급 차단
+- AuthService.reissue()에 상태 검증 로직 추가
+```
+
+---
+
+## Procedure
+
+### Step 0: Branch check
+1. Detect the base branch (see "Base Branch Detection" above)
+2. Check if the current branch is the base branch
+3. If on the base branch:
+   - Suggest a branch name to the user based on the changes
+   - Create the new branch and check out to it before committing
+4. If not on the base branch, continue to Step 1
+
+### Step 1: Sync with remote
+1. `git stash push --include-untracked` to save current changes, including untracked files (only if there are changes)
+2. `git pull --ff-only` to fast-forward to the latest remote commits
+3. `git stash pop` to re-apply changes; if it reports conflicts, resolve them before continuing
+
+### Step 2~8: Execute commits
+1. Use the git context above to understand current changes
+2. Determine the appropriate type for each change
+3. Stage logically related files together
+4. Create commit
+5. If changes span multiple concerns, split into 2~4 commits
+6. Report results (commit hash, message, branch name)

--- a/.agents/skills/phase-harness/agents/openai.yaml
+++ b/.agents/skills/phase-harness/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Phase Harness"
+  short_description: "TDD phase implementation workflow"
+  default_prompt: "Use the phase harness workflow to implement the selected project phase end to end."

--- a/.agents/skills/phase-harness/phases/01-clarify.md
+++ b/.agents/skills/phase-harness/phases/01-clarify.md
@@ -1,0 +1,36 @@
+# 01 Clarify
+
+Purpose: turn the user's phase request into a precise implementation scope.
+
+Read:
+
+- The user request.
+- The target phase file under `docs/superpowers/plans/phases/`.
+- The previous and next phase summaries when they affect prerequisites.
+
+Produce `.harness/artifacts/01-clarify.md` with:
+
+```markdown
+# 01 Clarify
+
+## Requested Scope
+
+- Phase:
+- Tasks:
+- Explicit user constraints:
+
+## Assumptions
+
+- ...
+
+## Questions
+
+- Required before implementation:
+- Can proceed with assumption:
+
+## User Decisions
+
+- ...
+```
+
+Ask the user only for decisions that materially change implementation, risk, measurements, or documentation. If a reasonable assumption is safe, state it and continue.

--- a/.agents/skills/phase-harness/phases/02-context.md
+++ b/.agents/skills/phase-harness/phases/02-context.md
@@ -1,0 +1,49 @@
+# 02 Context
+
+Purpose: gather codebase context and create the deep-dive learning brief.
+
+Read:
+
+- `.harness/artifacts/01-clarify.md`
+- Target phase plan.
+- Overall roadmap: `docs/superpowers/plans/2026-04-07-extreme-board-implementation.md`
+- `docs/progress/`
+- `backend/CLAUDE.md` when backend code is involved.
+- Relevant tests, models, repositories, services, routers, config, compose files, and scripts.
+
+Produce `.harness/artifacts/02-context.md` with:
+
+```markdown
+# 02 Context
+
+## Existing Structure
+
+- Relevant files:
+- Current behavior:
+- Existing tests:
+
+## Learning Brief
+
+| Topic | Why it matters | Talking point |
+|-------|----------------|---------------|
+| ... | ... | ... |
+
+## Trade-offs
+
+| Option | Pros | Cons | Current choice |
+|--------|------|------|----------------|
+| ... | ... | ... | ... |
+
+## Evidence Targets
+
+- Claims to prove:
+- Evidence type:
+- Before/after needed:
+- Validity risks:
+
+## Risks
+
+- ...
+```
+
+Keep the learning brief compact. Prefer details that help explain the phase in interviews, PRs, or a portfolio.

--- a/.agents/skills/phase-harness/phases/03-plan.md
+++ b/.agents/skills/phase-harness/phases/03-plan.md
@@ -1,0 +1,49 @@
+# 03 Plan
+
+Purpose: create a TDD implementation plan that can be reviewed before coding.
+
+Read:
+
+- `.harness/artifacts/01-clarify.md`
+- `.harness/artifacts/02-context.md`
+- The current git diff.
+
+Produce `.harness/artifacts/03-plan.md` with:
+
+```markdown
+# 03 Plan
+
+## Goal
+
+- ...
+
+## TDD Slices
+
+| Slice | RED | GREEN | REFACTOR | Files |
+|-------|-----|-------|----------|-------|
+| ... | ... | ... | ... | ... |
+
+## Evidence Plan
+
+| Claim | Evidence command/test | Expected result | Notes |
+|-------|-----------------------|-----------------|-------|
+| ... | ... | ... | ... |
+
+## Documentation Plan
+
+- Progress doc:
+- Diagrams:
+- Tables:
+
+## Acceptance Criteria
+
+- ...
+
+## Risks And Rollback
+
+- ...
+```
+
+Respect project boundaries. For this backend, keep SQLAlchemy in repositories unless the existing code has intentionally changed that architecture.
+
+After writing the plan, perform or request a senior-style plan review. Focus on regressions, invalid evidence, missing tests, contract drift, concurrency problems, and documentation gaps.

--- a/.agents/skills/phase-harness/phases/04-implement.md
+++ b/.agents/skills/phase-harness/phases/04-implement.md
@@ -1,0 +1,45 @@
+# 04 Implement
+
+Purpose: execute the approved plan in small TDD slices.
+
+Read:
+
+- `.harness/artifacts/03-plan.md`
+- `.harness/decisions.md` if present.
+- Current git diff before each major slice.
+
+Rules:
+
+- Write or update tests first when the task has testable behavior.
+- Confirm expected RED failure when practical.
+- Implement the smallest GREEN change.
+- Refactor only after tests pass.
+- Preserve unrelated user changes.
+- Update `.harness/tasks.json` when task tracking exists.
+
+For evidence or infra work:
+
+- Create the script, benchmark, migration, or command checklist before relying on it.
+- Run the smallest check that proves the tool works.
+- Capture raw output needed for the final progress note.
+
+Append to `.harness/artifacts/04-implementation.md`:
+
+```markdown
+# 04 Implementation
+
+## Completed Slices
+
+- Slice:
+  - Tests:
+  - Code:
+  - Evidence:
+
+## Deviations From Plan
+
+- ...
+
+## Open Items
+
+- ...
+```

--- a/.agents/skills/phase-harness/phases/05-evidence.md
+++ b/.agents/skills/phase-harness/phases/05-evidence.md
@@ -1,0 +1,52 @@
+# 05 Evidence
+
+Purpose: collect proof that the phase achieved its goal.
+
+Read:
+
+- `.harness/artifacts/03-plan.md`
+- `.harness/artifacts/04-implementation.md`
+- Test, benchmark, audit, smoke, or manual check output produced during implementation.
+
+Evidence can be performance data, correctness checks, consistency checks, operational proof, or deployment smoke results. Use the evidence type that matches the phase.
+
+Examples:
+
+- Performance phase: EXPLAIN ANALYZE, p95/p99, throughput, before/after latency.
+- Consistency phase: duplicate prevention, retry behavior, drift audit, consumer replay.
+- Infra phase: health checks, failover behavior, routing, dashboard/trace visibility.
+- Feature phase: API tests, state transition tests, validation errors, manual smoke.
+
+Produce `.harness/artifacts/05-evidence.md` with:
+
+````markdown
+# 05 Evidence
+
+## Evidence Summary
+
+| Claim | Evidence | Result | Notes |
+|-------|----------|--------|-------|
+| ... | ... | ... | ... |
+
+## Performance Data
+
+Include only when the phase has performance goals.
+
+| Metric | Before | After | Interpretation |
+|--------|--------|-------|----------------|
+| ... | ... | ... | ... |
+
+## Raw Commands
+
+```bash
+...
+```
+
+## Validity Notes
+
+- Dataset:
+- Environment:
+- Limitations:
+````
+
+For performance claims, use comparable before/after values. For non-performance claims, use claim/evidence/result rows instead of forcing fake metrics.

--- a/.agents/skills/phase-harness/phases/06-evaluate.md
+++ b/.agents/skills/phase-harness/phases/06-evaluate.md
@@ -1,0 +1,48 @@
+# 06 Evaluate
+
+Purpose: verify the final result like a senior reviewer.
+
+Read:
+
+- All `.harness/artifacts/*.md`
+- Current git diff.
+- Test output.
+- `.harness/artifacts/05-evidence.md`
+
+Run or confirm:
+
+- Targeted tests.
+- Broader tests when shared contracts changed.
+- Lint/type checks when the project uses them.
+- Manual API/DB/benchmark/audit commands required by the phase.
+- Final senior-style review, using a subagent when authorized and available.
+
+Produce `.harness/artifacts/06-evaluation.md` with:
+
+```markdown
+# 06 Evaluation
+
+## Checks Run
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| ... | ... | ... |
+
+## Evidence Review
+
+- Strong evidence:
+- Weak or missing evidence:
+- Measurement limitations:
+
+## Review Findings
+
+- Must fix:
+- Optional:
+- Deferred:
+
+## Residual Risk
+
+- ...
+```
+
+Fix material findings before reporting completion. If something cannot be fixed or verified, state the reason plainly.

--- a/.agents/skills/phase-harness/phases/07-report.md
+++ b/.agents/skills/phase-harness/phases/07-report.md
@@ -1,0 +1,75 @@
+# 07 Report
+
+Purpose: create the durable learning and portfolio artifact.
+
+Read:
+
+- `.harness/artifacts/02-context.md`
+- `.harness/artifacts/05-evidence.md`
+- `.harness/artifacts/06-evaluation.md`
+- Existing `docs/progress/_template.md`
+- Nearby progress docs for tone and density.
+
+Create or update `docs/progress/phase-XX-*.md`.
+
+Recommended structure:
+
+````markdown
+# Phase N: 제목
+
+> 완료일: YYYY-MM-DD
+
+## 구현 요약
+
+- ...
+
+## 학습 노트
+
+- 핵심 개념:
+- 트레이드오프:
+- 포트폴리오에서 말할 점:
+
+## 설계
+
+```mermaid
+flowchart TD
+    A["Before"] --> B["Problem"]
+    B --> C["After"]
+```
+
+## Evidence
+
+| Claim | Evidence | Result | Notes |
+|-------|----------|--------|-------|
+| ... | ... | ... | ... |
+
+## 테스트 결과
+
+```bash
+...
+```
+
+## 트러블슈팅
+
+- ...
+````
+
+If the phase has performance goals, include a `## 측정 결과` table. If it does not, use `## 검증 결과` or `## Evidence`. Avoid duplicating long explanations already present in the phase plan.
+
+Produce `.harness/artifacts/07-report.md` with:
+
+```markdown
+# 07 Report
+
+## Progress Document
+
+- Path:
+- Sections written:
+- Diagrams:
+- Evidence tables:
+
+## Notes
+
+- Deferred documentation:
+- Anything intentionally omitted:
+```

--- a/.agents/skills/phase-harness/skill.md
+++ b/.agents/skills/phase-harness/skill.md
@@ -1,0 +1,183 @@
+---
+name: phase-harness
+description: End-to-end phase implementation harness for this learning project. Use when the user asks to implement, proceed with, review, or execute a project phase or phase task, especially under docs/superpowers/plans/phases. Guides Codex through clarify, deep-dive learning notes, codebase review, TDD planning, senior-style plan review, user approval, implementation, evidence collection, evaluation, reporting, and verification.
+---
+
+# Phase Harness
+
+Use this skill as an orchestrator for implementing one phase or a bounded set of tasks from the phase plans. Keep short-lived harness state in `.harness/` and final learning artifacts in `docs/progress/`.
+
+Optimize for three outcomes:
+
+1. Correct code that follows the existing architecture.
+2. A clear learning trail: concepts, trade-offs, measurements, and diagrams.
+3. Portfolio-ready evidence without bloated or repetitive writing.
+
+Keep the project voice: Korean, technical, direct, no emoji, no marketing tone.
+
+## Artifact Pipeline
+
+Create `.harness/artifacts/` when the workflow starts. Each stage writes a concise artifact for the next stage:
+
+```text
+01-clarify.md
+  -> 02-context.md
+  -> 03-plan.md
+  -> 04-implementation.md
+  -> 05-evidence.md
+  -> 06-evaluation.md
+  -> 07-report.md
+```
+
+Optional state files:
+
+- `.harness/tasks.json`: task list and status when the phase has many steps.
+- `.harness/decisions.md`: user decisions that affect scope, review findings, or deferred work.
+
+`.harness/` is working state. Do not commit it unless the user explicitly asks. The durable output is the code, tests, evidence scripts, benchmark results when applicable, and `docs/progress/phase-XX-*.md`.
+
+## Phase Instructions
+
+Use the phase prompt files in this directory:
+
+- `phases/01-clarify.md`
+- `phases/02-context.md`
+- `phases/03-plan.md`
+- `phases/04-implement.md`
+- `phases/05-evidence.md`
+- `phases/06-evaluate.md`
+- `phases/07-report.md`
+
+When subagents are authorized and available, run the relevant phase prompt in a subagent and require it to write the expected artifact. When subagents are unavailable or not authorized, run the same phase locally and write the artifact yourself.
+
+## Orchestration Flow
+
+### 1. Clarify Scope
+
+Run `phases/01-clarify.md`. Present material questions to the user, record answers in `.harness/artifacts/01-clarify.md`, and continue only after scope is clear.
+
+### 2. Deep-Dive Learning Note
+
+Run `phases/02-context.md`. Include the learning brief in `.harness/artifacts/02-context.md` so it can feed both implementation and the final progress document.
+
+### 3. Inspect Structure And Code
+
+The context phase must inspect the phase plan, roadmap, progress docs, backend guidance, and relevant code. Prefer `rg`, `rg --files`, `sed`, `nl`, and `git diff`. Preserve unrelated user changes.
+
+### 4. Build A TDD Plan
+
+Run `phases/03-plan.md`. The plan must include RED/GREEN/REFACTOR slices, evidence commands or checks, documentation outputs, risk notes, and acceptance criteria.
+
+### 5. Senior Plan Review
+
+Review `.harness/artifacts/03-plan.md` before implementation. Use a subagent when authorized; otherwise do a local senior review. Record findings and recommendations in `.harness/decisions.md`.
+
+### 6. Ask Before Applying Review Changes
+
+Show the user:
+
+- Implementation plan summary.
+- Senior review findings.
+- Which findings you recommend applying now.
+- Which findings are optional or deferred.
+
+Ask whether to apply the review changes before coding. If the user already gave explicit permission to proceed without another checkpoint, continue and document the assumption.
+
+### 7. Implement With TDD
+
+Run `phases/04-implement.md`. Work in small vertical slices and update `.harness/tasks.json` if it exists. For evidence or infra tasks where classic unit TDD does not fit, create executable verification scripts, benchmark checks, smoke checks, or audit checks first, then make them pass.
+
+### 8. Collect Evidence
+
+Run `phases/05-evidence.md`. Evidence means whatever proves the phase goal:
+
+- Performance: benchmark, EXPLAIN ANALYZE, p95/p99, throughput.
+- Correctness: tests, invariants, duplicate prevention, state transitions.
+- Consistency: retry behavior, idempotency, drift checks, consumer replay.
+- Operations: health checks, failover behavior, dashboards, traces.
+- Deployment: smoke checks, endpoint reachability, rollback evidence.
+
+For performance phases, capture before/after values using the same command, dataset size, and environment. For non-performance phases, capture claim/evidence/result rows. Do not claim success without evidence.
+
+### 9. Evaluate Like A Reviewer
+
+Run `phases/06-evaluate.md`. Include targeted tests, broader checks when needed, evidence validity, and a final senior-style review of diff, tests, evidence, and docs.
+
+### 10. Write The Phase Result Document
+
+Run `phases/07-report.md`. Create or update a concise Markdown progress note under `docs/progress/`.
+
+Use the existing template and tone. Include only what helps future recall:
+
+````markdown
+# Phase N: 제목
+
+> 완료일: YYYY-MM-DD
+
+## 구현 요약
+
+- 핵심 변경 사항
+- 주요 파일/구조
+
+## 학습 노트
+
+- 개념
+- 트레이드오프
+- 면접/포트폴리오에서 말할 포인트
+
+## 설계
+
+```mermaid
+flowchart TD
+    A["Before"] --> B["Bottleneck"]
+    B --> C["After"]
+```
+
+## Evidence
+
+| Claim | Evidence | Result | Notes |
+|-------|----------|--------|-------|
+| ... | ... | ... | ... |
+
+## 테스트 결과
+
+```bash
+...
+```
+
+## 트러블슈팅
+
+- 문제와 해결
+````
+
+Diagram guidance:
+
+- Prefer Mermaid in Markdown for architecture, flow, sequence, and state transitions.
+- Use Excalidraw only when the user explicitly asks or the visual is too spatial for Mermaid.
+- Keep diagrams small enough to read in a PR.
+
+Writing guidance:
+
+- No emoji.
+- Avoid repeated explanations already present in the phase plan.
+- Prefer tables for trade-offs and measurements.
+- Explain why the result matters, not every mechanical edit.
+
+## Completion Report
+
+End with:
+
+- What changed.
+- What tests and evidence checks ran.
+- Where the progress document is.
+- Any unresolved risks or skipped checks.
+- Commit/PR status only if the user asked for it.
+
+Do not leave needed dev servers, long-running tests, or subagents dangling.
+
+## Error Handling
+
+- If a phase artifact is missing or malformed, rerun that phase.
+- If a subagent reports a blocker, present the blocker and a recommended next step.
+- If the user says "redo phase N", rerun only that phase and downstream phases affected by it.
+- If tests or measurements cannot run, document the exact blocker and do not claim completion.

--- a/.agents/skills/pr/skill.md
+++ b/.agents/skills/pr/skill.md
@@ -1,0 +1,119 @@
+---
+name: pr
+description: Commit, push, and open a PR. Use when the user asks to create a PR (e.g. "PR 만들어줘", "PR 생성해줘", "풀리퀘 올려줘").
+argument-hint: "[issue-number]"
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git branch:*), Bash(git push:*), Bash(gh pr create:*), Bash(gh pr edit:*)
+---
+
+# PR Creation Skill
+
+## Input
+
+`$ARGUMENTS`
+
+Format: `<issue-number>` (optional)
+Examples:
+- `/pr 42` → PR 생성 후 GitHub Issue #42와 development 연동 (PR merge 시 자동 close)
+- `/pr` → issue 연동 없이 PR 생성
+
+## Current Git Context
+
+Current git status: !git status
+Current git diff (staged and unstaged changes): !git diff HEAD
+Current branch: !git branch --show-current
+Recent commits since branching: !git log --oneline origin/HEAD..HEAD
+
+---
+
+## Base Branch Detection
+
+Determine the base branch using this priority:
+1. If the project AGENTS.md specifies a main/base branch, use that
+2. Try `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'`
+3. Default: `main`
+
+---
+
+## Pre-checks
+
+1. Verify current branch is NOT the base branch — if on base branch, warn and abort
+2. Check for uncommitted changes — if any, warn the user to run `/commit` first
+
+---
+
+## PR Template
+
+`.github/PULL_REQUEST_TEMPLATE.md` 를 기반으로 아래 항목을 채워 PR body를 작성한다.
+issue-number가 제공된 경우, Background 아래에 `Closes #N` 을 추가한다 — GitHub이 이를 인식해 PR merge 시 issue를 자동 close하고 development 패널에 연동한다.
+
+```markdown
+## Background
+
+{이 PR의 배경. 어떤 Phase인지, 무엇을 목표로 했는지. 1~3줄.}
+
+Closes #{issue-number}   ← issue-number가 있을 때만 포함
+
+## 구현 내용
+
+{무엇을 구현했는지. 핵심 변경 사항을 번호 목록으로.}
+
+1. ...
+
+## 설계 결정 & 트레이드오프
+
+{왜 이 방식을 선택했는지. 고려한 대안과 포기한 이유.}
+
+| 결정 | 이유 | 포기한 대안 |
+|------|------|------------|
+| ... | ... | ... |
+
+## 성능 측정
+
+{최적화 전/후 수치. 목표 대비 실제 결과. 해당 없으면 "N/A"}
+
+| 지표 | 목표 | Before | After |
+|------|------|--------|-------|
+| TPS | ... | ... | ... |
+| P99 Latency | ... | ... | ... |
+
+## 참고 자료
+
+- ...
+
+## 코멘트
+
+{리뷰어나 미래의 나에게 전달할 메모. 없으면 생략.}
+```
+
+**작성 원칙**: diff를 나열하지 않는다. 변경의 *무엇(What)*, *왜(Why)*, *어떻게(How)* 를 서술해 코드를 읽지 않아도 맥락을 파악할 수 있게 쓴다.
+
+---
+
+## Procedure
+
+### Step 1: Analyze
+- 위 git context를 바탕으로 변경 내용 파악
+- 필요 시 변경된 파일 직접 읽어 context 보완
+- PR 제목과 body 초안 작성
+  - 제목 형식: `type: 한국어 요약` (50자 이내, 명령문, 끝 마침표 없음)
+  - type은 커밋 컨벤션과 동일: feat / fix / refactor / style / chore / test / docs
+  - 브랜치의 커밋들을 종합해 가장 대표적인 type 하나 선택
+
+### Step 2: Preview & confirm
+다음을 사용자에게 보여주고 승인 대기:
+- PR 제목
+- PR body 미리보기
+- `{base_branch}` ← `{current_branch}`
+
+승인 시 Step 3 진행, 수정 요청 시 재작성 후 재확인.
+
+### Step 3: Push & create PR
+```bash
+git push -u origin {current_branch}
+gh pr create --base {base_branch} --title "{title}" --body "{body}"
+```
+
+### Step 4: Report
+- PR URL
+- 제목
+- base ← head 브랜치명


### PR DESCRIPTION
## Background

Phase 단위 구현을 clarify, context, plan, implementation, evidence, evaluation, report 흐름으로 진행하기 위한 로컬 Codex 스킬을 추가한다. 학습 목적의 Phase 구현에서 TDD, 측정/검증, 문서화를 일관되게 남기는 것이 목표다.

## 구현 내용

1. `phase-harness` 스킬 추가
   - Phase 구현을 7단계 artifact pipeline으로 진행
   - `.harness/artifacts/` 작업 기록과 `docs/progress/` 최종 문서 역할 분리
   - 성능 측정이 없는 Phase도 처리할 수 있도록 `Evidence` 단계 도입

2. 단계별 phase prompt 추가
   - `01-clarify`
   - `02-context`
   - `03-plan`
   - `04-implement`
   - `05-evidence`
   - `06-evaluate`
   - `07-report`

3. 로컬 git 자동화 스킬 추가
   - `commit` 스킬로 커밋 메시지/브랜치 절차 정리
   - `pr` 스킬로 PR 본문 작성/생성 절차 정리

## 설계 결정 & 트레이드오프

| 결정 | 이유 | 포기한 대안 |
|------|------|------------|
| 단계별 prompt 파일 분리 | 각 단계 산출물을 다음 단계 입력으로 재사용하고, subagent에 좁은 범위로 위임하기 쉬움 | 단일 `skill.md`에 전체 절차를 모두 작성 |
| `Evidence` 단계 사용 | 성능 수치가 있는 Phase와 정합성/운영/배포 검증 Phase를 모두 표현 가능 | `Measurement` 전용 단계로 제한 |
| `.harness/`와 `docs/progress/` 분리 | 작업 중간 기록과 최종 학습 문서를 구분해 재개성과 문서 품질을 높임 | 구현 완료 후 기억에 의존해 progress 문서 작성 |
| commit/pr 스킬을 별도 커밋으로 추가 | phase-harness와 git 자동화 스킬의 관심사를 분리 | 하나의 커밋에 모든 로컬 스킬 추가 |

## 성능 측정

N/A

스킬/문서 추가 작업으로 런타임 성능 측정 대상이 아니다. 대신 `quick_validate.py`로 스킬 구조를 검증했다.

| 지표 | 목표 | Before | After |
|------|------|--------|-------|
| Skill validation | 통과 | N/A | PASS |

## 코멘트

`phase-harness`는 `.harness/`를 작업 상태로 사용하지만, 기본적으로 커밋하지 않도록 명시했다. 최종 산출물은 코드, 테스트, evidence 결과, `docs/progress/phase-XX-*.md`로 남기는 흐름이다.